### PR TITLE
Add ability to configure flush_interval

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # https://github.com/statsd/statsd/blob/master/Dockerfile
-FROM node:20-alpine3.21
+FROM node:22-alpine3.21
 
 # Update core packages
 RUN apk update && apk upgrade

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 [Dockerhub](https://hub.docker.com/r/dblworks/statsd)
 
+## Configuration
+
+You can configure the statsd server by setting the following environment variables:
+
+- `STATSD_FLUSH_INTERVAL_IN_MS`: The interval in milliseconds to flush metrics to each backend. Default is 900000ms (15 minutes).
+
 ## Building
 
 On a x86 chip

--- a/backends/cloudwatch.js
+++ b/backends/cloudwatch.js
@@ -77,6 +77,7 @@ ConsoleBackend.prototype.status = function(write) {
 };
 
 exports.init = function(startupTime, config, events) {
+  config['flushInterval'] ||= process.env.STATSD_FLUSH_INTERVAL_IN_MS
   var instance = new ConsoleBackend(startupTime, config, events);
   return true;
 };

--- a/backends/cloudwatch.js
+++ b/backends/cloudwatch.js
@@ -114,7 +114,9 @@ ConsoleBackend.prototype.status = function (write) {
 };
 
 exports.init = function(startupTime, config, events) {
-  config['flushInterval'] ||= process.env.STATSD_FLUSH_INTERVAL_IN_MS
+  console.log("[StatsD] Initializing Console Backend");
+  console.log("[StatsD] flushInterval set to ", config['flushInterval'], "ms");
+
   var instance = new ConsoleBackend(startupTime, config, events);
   return true;
 };

--- a/config.js
+++ b/config.js
@@ -3,7 +3,7 @@
 {
   debug: false,
   dumpMessages: false, // Dump all incoming messages to the log
-  flushInterval: 900000, // interval (in ms) to flush metrics to each backend
+  flushInterval: process.env.STATSD_FLUSH_INTERVAL_IN_MS || 900000, // interval (in ms) to flush metrics to each backend
   deleteIdleStats: true,
   log: {
     backend: 'stdout',


### PR DESCRIPTION
### Why?

At SQUAKE we realised that we're missing some metrics in production. Turns out our statsd sidecar produces so much logs in 15 min that it exceeds CloudWatch limit (256KB). We flush data every 15 min (90_000ms) right now, at SQUAKE we need a way to make this number smaller, hence the PR.

You can now add `STATSD_FLUSH_INTERVAL_IN_MS` to your env vars in order to control flushes better.

### Testing

Here's the logs from Cloudwatch, from our sidecar container which runs statsd, as you can see we configured it to flush every 1 min, it's exactly what it does

```
[StatsD] 2025-07-11T16:29:18.000Z - {"counters":{},"timers":{},"gauges":{}}
[StatsD] 2025-07-11T16:28:18.000Z - {"counters":{},"timers":{},"gauges":{}}
[StatsD] 2025-07-11T16:27:18.000Z - {"counters":{},"timers":{},"gauges":{}}
[StatsD] Initializing Console Backend
[StatsD] flushInterval set to 60000 ms
```

### Release: 

[Dockerhub](https://hub.docker.com/layers/dblworks/statsd/v0.12.0/images/sha256-4e4d9aea6a9de2cc2e2c283b56f6180490c3d1d18575816db9b9bd0ebe07e58a)